### PR TITLE
Force gcc to C99 mode

### DIFF
--- a/base64/Makefile
+++ b/base64/Makefile
@@ -5,7 +5,7 @@ APPS = encode64 decode64
 SRCS = base64.c
 
 # Define compiler flags here
-CFLAGS = -g -O0 -Werror
+CFLAGS = -std=c99 -g -O0 -Werror
 
 # External packages
 PKGS = glib-2.0

--- a/fruitgame/Makefile
+++ b/fruitgame/Makefile
@@ -1,5 +1,5 @@
 PROGS = fruitgame
-CFLAGS = -Werror
+CFLAGS = -std=c99 -Werror
 
 all: $(PROGS)
 

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -1,6 +1,6 @@
 SUBDIRS = plugins
 
-export CFLAGS = -Wall -Werror -g
+export CFLAGS = -std=c99 -Wall -Werror -g
 
 all: convert $(SUBDIRS)
 


### PR DESCRIPTION
This avoids compiler errors on my gcc 4.8.4.

Signed-off-by: Samuel Casa <samuelcasa9@gmail.com>